### PR TITLE
Added API Blueprints for API test mocking

### DIFF
--- a/docs/apib/aicc.apib
+++ b/docs/apib/aicc.apib
@@ -1,0 +1,83 @@
+FORMAT: 1A
+
+# GET /aicc
+
++ Response 200 (application/json)
+
+# PUT /aicc
+
++ Response 200 (application/json)
+
++ Response 400
+
+# GET /aicc/network/ipdisable
+
++ Response 200 (application/json)
+
++ Response 404
+
+# PUT /aicc/network/ipdisable
+
++ Response 200 (application/json)
+
++ Response 400
+
+# GET /aicc/network/host
+
++ Response 200 (application/json)
+
+# PUT /aicc/network/host
+
++ Response 200 (application/json)
+
++ Response 400
+
+# GET /aicc/network/interfaces/{interface}
+
++ Response 200 (application/json)
+
++ Response 400
+
+# PUT /aicc/network/interfaces/{interface}
+
++ Response 200 (application/json)
++ Response 400
++ Response 401
++ Response 403
++ Response 404
++ Response 409
++ Response 500
+
+# GET /aicc/network/routes
+
++ Response 200 (application/json)
+
+# PUT /aicc/network/routes
+
++ Response 200 (application/json)
+
++ Response 400
+
+# GET /aicc/subscriptions
+
++ Response 200 (application/json)
+
++ Response 400
+
+# PUT /aicc/subscriptions
+
++ Response 200 (application/json)
++ Response 400
++ Response 409
+
+# DELETE /aicc/subscriptions/{id}
+
++ Response 200 (application/json)
+
++ Response 404
+
+# GET /aicc/subscriptions/{id}
+
++ Response 200 (application/json)
+
++ Response 400

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,14 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'xclarity_client'
+require 'apib/mock_server'
+require 'webmock/rspec'
+
+base_url = "http://example.com"
+blueprint = Pathname(__dir__).join("..", "docs/apib", "aicc.apib").read
+app = Apib::MockServer.new(base_url, blueprint)
+
+RSpec.configure do |config|
+  config.before do
+    stub_request(:any, /#{base_url}/).to_rack(app)
+  end
+end

--- a/spec/xclarity_client_spec.rb
+++ b/spec/xclarity_client_spec.rb
@@ -5,7 +5,18 @@ describe XclarityClient do
     expect(XclarityClient::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  # TODO: Actuall create real tests!
+  describe 'GET /aicc' do
+    it 'should respond with information about the Lenovo XClarity Administrator' do
+      response = 200
+      expect(response).to eq(200)
+    end
+  end
+
+  describe 'GET /aicc/network/ipdisable' do
+    it 'should respond with the IPv6 and IPv6 addresses enablement state.' do
+      response = 200
+      expect(response).to eq(200)
+    end
   end
 end

--- a/xclarity_client.gemspec
+++ b/xclarity_client.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Julian Cheal"]
   spec.email         = ["jcheal@redhat.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Write a short summary, because Rubygems requires one.}
+  spec.description   = %q{Write a longer description or delete this line.}
+  spec.homepage      = "https://github.com/juliancheal/xclarity_client"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "apib-mock_server", "~> 1.0.3"
+  spec.add_development_dependency "webmock", "~> 2.1.0"
 end


### PR DESCRIPTION
Using `apib/mock_server` gem to create a mock server based on API
Blueprints files (which are Markdown files to describe an API)

This not only allows us to generate API documentation, but also
locally test our client.