### PR TITLE
Enables query string settings through options hash

### DIFF
--- a/lib/xclarity_client/cabinet_management.rb
+++ b/lib/xclarity_client/cabinet_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, Cabinet::BASE_URI)
     end
 
-    def population
-      get_all_resources(Cabinet)
+    def population(opts = {})
+      get_all_resources(Cabinet, opts)
     end
 
   end

--- a/lib/xclarity_client/canister_management.rb
+++ b/lib/xclarity_client/canister_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, Canister::BASE_URI)
     end
 
-    def population
-      get_all_resources(Canister)
+    def population(opts = {})
+      get_all_resources(Canister, opts)
     end
 
   end

--- a/lib/xclarity_client/chassi_management.rb
+++ b/lib/xclarity_client/chassi_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, Chassi::BASE_URI)
     end
 
-    def population
-      get_all_resources(Chassi)
+    def population(opts = {})
+      get_all_resources(Chassi, opts)
     end
 
   end

--- a/lib/xclarity_client/client.rb
+++ b/lib/xclarity_client/client.rb
@@ -5,32 +5,32 @@ module XClarityClient
       @connection = connection
     end
 
-    def discover_nodes
-      NodeManagement.new(@connection).population
+    def discover_nodes(opts = {})
+      NodeManagement.new(@connection).population opts
     end
 
-    def discover_scalableComplexes
-      ScalableComplexManagement.new(@connection).population
+    def discover_scalableComplexes(opts = {})
+      ScalableComplexManagement.new(@connection).population opts
     end
 
-    def discover_cabinet
-      CabinetManagement.new(@connection).population
+    def discover_cabinet(opts = {})
+      CabinetManagement.new(@connection).population opts
     end
 
     def fetch_cabinet(uuids = nil, includeAttributes = nil, excludeAttributes = nil)
       CabinetManagement.new(@connection).get_object(uuids, includeAttributes, excludeAttributes, Cabinet)
     end
 
-    def discover_canisters
-      CanisterManagement.new(@connection).population
+    def discover_canisters(opts = {})
+      CanisterManagement.new(@connection).population opts
     end
 
     def fetch_canisters(uuids = nil, includeAttributes = nil, excludeAttributes = nil)
       CanisterManagement.new(@connection).get_object(uuids, includeAttributes, excludeAttributes, Canister)
     end
 
-    def discover_cmms
-      CmmManagement.new(@connection).population
+    def discover_cmms(opts = {})
+      CmmManagement.new(@connection).population opts
     end
 
     def fetch_cmms(uuids = nil, includeAttributes = nil, excludeAttributes = nil)
@@ -41,28 +41,28 @@ module XClarityClient
       FanManagement.new(@connection).get_object(uuids, includeAttributes, excludeAttributes, Fan)
     end
 
-    def discover_fans
-      FanManagement.new(@connection).population
+    def discover_fans(opts = {})
+      FanManagement.new(@connection).population opts
     end
 
-    def discover_switches
-      SwitchManagement.new(@connection).population
+    def discover_switches(opts = {})
+      SwitchManagement.new(@connection).population opts
     end
 
-    def discover_fan_muxes
-      FanMuxManagement.new(@connection).population
+    def discover_fan_muxes(opts = {})
+      FanMuxManagement.new(@connection).population opts
     end
 
     def fetch_fan_muxes(uuids = nil, includeAttributes = nil, excludeAttributes = nil)
       FanMuxManagement.new(@connection).get_object(uuids, includeAttributes, excludeAttributes, FanMux)
     end
 
-    def discover_chassis
-      ChassiManagement.new(@connection).population
+    def discover_chassis(opts = {})
+      ChassiManagement.new(@connection).population opts
     end
 
-    def discover_power_supplies
-      PowerSupplyManagement.new(@connection).population
+    def discover_power_supplies(opts = {})
+      PowerSupplyManagement.new(@connection).population opts
     end
 
     def fetch_nodes(uuids = nil, includeAttributes = nil, excludeAttributes = nil)

--- a/lib/xclarity_client/cmm_management.rb
+++ b/lib/xclarity_client/cmm_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, Cmm::BASE_URI)
     end
 
-    def population
-      get_all_resources(Cmm)
+    def population(opts = {})
+      get_all_resources(Cmm, opts)
     end
 
   end

--- a/lib/xclarity_client/fan_management.rb
+++ b/lib/xclarity_client/fan_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, Fan::BASE_URI)
     end
 
-    def population
-      get_all_resources(Fan)
+    def population(opts = {})
+      get_all_resources(Fan, opts)
     end
 
   end

--- a/lib/xclarity_client/fan_mux_management.rb
+++ b/lib/xclarity_client/fan_mux_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, FanMux::BASE_URI)
     end
 
-    def population
-      get_all_resources(FanMux)
+    def population(opts = {})
+      get_all_resources(FanMux, opts)
     end
 
   end

--- a/lib/xclarity_client/node_management.rb
+++ b/lib/xclarity_client/node_management.rb
@@ -10,8 +10,8 @@ module XClarityClient
       super(conf, Node::BASE_URI)
     end
 
-    def population
-      get_all_resources(Node)
+    def population(opts = {})
+      get_all_resources(Node, opts)
     end
 
   end

--- a/lib/xclarity_client/power_supply_management.rb
+++ b/lib/xclarity_client/power_supply_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, PowerSupply::BASE_URI)
     end
 
-    def population
-      get_all_resources(PowerSupply)
+    def population(opts = {})
+      get_all_resources(PowerSupply, opts)
     end
 
   end

--- a/lib/xclarity_client/scalable_complex_management.rb
+++ b/lib/xclarity_client/scalable_complex_management.rb
@@ -9,8 +9,8 @@ module XClarityClient
       super(conf, ScalableComplex::BASE_URI)
     end
 
-    def population
-      get_all_resources(ScalableComplex)
+    def population(opts = {})
+      get_all_resources(ScalableComplex, opts)
     end
 
   end

--- a/lib/xclarity_client/switch_management.rb
+++ b/lib/xclarity_client/switch_management.rb
@@ -8,8 +8,8 @@ module XClarityClient
       super(conf, Switch::BASE_URI)
     end
 
-    def population
-      get_all_resources(Switch)
+    def population(opts = {})
+      get_all_resources(Switch, opts)
     end
 
   end

--- a/lib/xclarity_client/xclarity_base.rb
+++ b/lib/xclarity_client/xclarity_base.rb
@@ -32,8 +32,9 @@ module XClarityClient
 
     private
 
-    def connection(uri = "", options = {})
-      @conn.get(uri)
+    def connection(uri = "", opts = {})
+      query = opts.size > 0 ? "?" + opts.map {|k, v| "#{k}=#{v}"}.join(",") : ""
+      @conn.get(uri + query)
     end
 
     def authentication(conf)

--- a/lib/xclarity_client/xclarity_management_mixin.rb
+++ b/lib/xclarity_client/xclarity_management_mixin.rb
@@ -2,8 +2,8 @@ module XClarityClient
   module ManagementMixin
 
 
-    def get_all_resources (resource)
-      response = connection(resource::BASE_URI)
+    def get_all_resources (resource, opts = {})
+      response = connection(resource::BASE_URI, opts)
 
       return [] unless response.success?
       


### PR DESCRIPTION
The XLCA API allows query string parameters. This pull request allows `XClarityClient::XClarityBase::connection` to receive a opts hash that sets query string parameters, thus you can do things like:

```
client = XClarityClient::Client.new...
client.discover_cabinet(status: "includestandalone")
```